### PR TITLE
fix: expand memory on reading prev. untouched location

### DIFF
--- a/packages/vm/src/evm/opcodes/functions.ts
+++ b/packages/vm/src/evm/opcodes/functions.ts
@@ -652,7 +652,9 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x51,
     function (runState) {
       const pos = runState.stack.pop()
-      const word = runState.memory.read(pos.toNumber(), 32)
+      const posNum = pos.toNumber()
+      const word = runState.memory.read(posNum, 32)
+      runState.memory.extend(posNum, 32)
       runState.stack.push(new BN(word))
     },
   ],


### PR DESCRIPTION
Memory is expanded by word when accessing previously untouched memory word ([relevant docs](https://docs.soliditylang.org/en/v0.8.13/introduction-to-smart-contracts.html#storage-memory-and-the-stack)). That applies to read operation on memory too.